### PR TITLE
Remove xy and ct config from default config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 out/*
 *.vsix
+.vscode-test/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,14 +8,13 @@
 			"name": "Run Extension",
 			"type": "extensionHost",
 			"request": "launch",
-			"runtimeExecutable": "${execPath}",
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}"
 			],
 			"outFiles": [
 				"${workspaceFolder}/out/**/*.js"
 			],
-			"preLaunchTask": "npm: watch"
+			"preLaunchTask": "${defaultBuildTask}"
 		},
 		{
 			"name": "Extension Tests",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1142,18 +1142,18 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       }
     },
     "mocha": {
@@ -1186,6 +1186,21 @@
             "minimatch": "^3.0.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
           }
         }
       }
@@ -1644,13 +1659,13 @@
       }
     },
     "tar": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
       "dev": true,
       "requires": {
         "block-stream": "*",
-        "fstream": "^1.0.2",
+        "fstream": "^1.0.12",
         "inherits": "2"
       }
     },

--- a/src/hue/default_ambient_lights_rules.ts
+++ b/src/hue/default_ambient_lights_rules.ts
@@ -5,11 +5,6 @@ export const defaultState: State = { // White
 	bri: 254,
 	hue: 42798,
 	sat: 84,
-	xy: [
-		0.3064,
-		0.3111
-	],
-	ct: 153
 };
 
 export const defaultAmbientLightsRules: AmbientLightsRules = {
@@ -19,11 +14,6 @@ export const defaultAmbientLightsRules: AmbientLightsRules = {
 			bri: 254,
 			hue: 36881,
 			sat: 254,
-			xy: [
-				0.1612,
-				0.3577
-			],
-			ct: 153
 		}
   },
   coffeescript: {
@@ -32,11 +22,6 @@ export const defaultAmbientLightsRules: AmbientLightsRules = {
 			bri: 254,
 			hue: 6016,
 			sat: 254,
-			xy: [
-				0.5689,
-				0.4004
-			],
-			ct: 500
 		}
   },
   c: {
@@ -45,11 +30,6 @@ export const defaultAmbientLightsRules: AmbientLightsRules = {
 			bri: 254,
 			hue: 41200,
 			sat: 232,
-			xy: [
-				0.1771,
-				0.2397
-			],
-			ct: 153
 		}
   },
   cpp: {
@@ -58,11 +38,6 @@ export const defaultAmbientLightsRules: AmbientLightsRules = {
 			bri: 254,
 			hue: 46247,
 			sat: 254,
-			xy: [
-				0.1539,
-				0.0735
-			],
-			ct: 153
 		}
   },
   csharp: {
@@ -71,11 +46,6 @@ export const defaultAmbientLightsRules: AmbientLightsRules = {
 			bri: 254,
 			hue: 48770,
 			sat: 245,
-			xy: [
-				0.2082,
-				0.0819
-			],
-			ct: 153
 		}
   },
   css: {
@@ -84,11 +54,6 @@ export const defaultAmbientLightsRules: AmbientLightsRules = {
 			bri: 254,
 			hue: 45048,
 			sat: 254,
-			xy: [
-				0.1548,
-				0.1099
-			],
-			ct: 153
 		}
   },
   diff: {
@@ -97,11 +62,6 @@ export const defaultAmbientLightsRules: AmbientLightsRules = {
 			bri: 254,
 			hue: 46553,
 			sat: 25,
-			xy: [
-				0.3581,
-				0.346
-			],
-			ct: 153
 		}
   },
   dockerfile: {
@@ -110,11 +70,6 @@ export const defaultAmbientLightsRules: AmbientLightsRules = {
 			bri: 254,
 			hue: 46553,
 			sat: 25,
-			xy: [
-				0.1415,
-				0.131
-			],
-			ct: 152
 		}
   },
   go: {
@@ -123,11 +78,6 @@ export const defaultAmbientLightsRules: AmbientLightsRules = {
 			bri: 254,
 			hue: 44365,
 			sat: 254,
-			xy: [
-				0.147,
-				0.204
-			],
-			ct: 153
 		}
   },
   html: {
@@ -136,11 +86,6 @@ export const defaultAmbientLightsRules: AmbientLightsRules = {
 			bri: 254,
 			hue: 41957,
 			sat: 254,
-			xy: [
-				0.5024,
-				0.4032
-			],
-			ct: 153
 		}
   },
   java: {
@@ -149,11 +94,6 @@ export const defaultAmbientLightsRules: AmbientLightsRules = {
 			bri: 254,
 			hue: 126,
 			sat: 247,
-			xy: [
-				0.6804,
-				0.3121
-			],
-			ct: 153
 		}
   },
   javascriptreact: {
@@ -162,11 +102,6 @@ export const defaultAmbientLightsRules: AmbientLightsRules = {
 			bri: 254,
 			hue: 41385,
 			sat: 226,
-			xy: [
-				0.1822,
-				0.2382
-			],
-			ct: 153
 		}
   },
   less: {
@@ -175,11 +110,6 @@ export const defaultAmbientLightsRules: AmbientLightsRules = {
 			bri: 254,
 			hue: 46306,
 			sat: 254,
-			xy: [
-				0.1538,
-				0.0718
-			],
-			ct: 153
 		}
   },
   perl: {
@@ -188,11 +118,6 @@ export const defaultAmbientLightsRules: AmbientLightsRules = {
 			bri: 254,
 			hue: 41084,
 			sat: 254,
-			xy: [
-				0.1579,
-				0.2302
-			],
-			ct: 153
 		}
   },
   php: {
@@ -201,11 +126,6 @@ export const defaultAmbientLightsRules: AmbientLightsRules = {
 			bri: 254,
 			hue: 41084,
 			sat: 254,
-			xy: [
-				0.2597,
-				0.099
-			],
-			ct: 153
 		}
   },
   jade: {
@@ -214,11 +134,6 @@ export const defaultAmbientLightsRules: AmbientLightsRules = {
 			bri: 254,
 			hue: 50751,
 			sat: 254,
-			xy: [
-				0.2002,
-				0.4276
-			],
-			ct: 153
 		}
   },
   python: {
@@ -227,11 +142,6 @@ export const defaultAmbientLightsRules: AmbientLightsRules = {
 			bri: 254,
 			hue: 12047,
 			sat: 91,
-			xy: [
-				0.4039,
-				0.4183
-			],
-			ct: 281
 		}
   },
   r: {
@@ -240,11 +150,6 @@ export const defaultAmbientLightsRules: AmbientLightsRules = {
 			bri: 254,
 			hue: 39222,
 			sat: 192,
-			xy: [
-				0.2133,
-				0.3087
-			],
-			ct: 153
 		}
   },
   ruby: {
@@ -253,11 +158,6 @@ export const defaultAmbientLightsRules: AmbientLightsRules = {
 			bri: 254,
 			hue: 61354,
 			sat: 195,
-			xy: [
-				0.5255,
-				0.2788
-			],
-			ct: 497
 		}
   },
   scss: {
@@ -266,11 +166,6 @@ export const defaultAmbientLightsRules: AmbientLightsRules = {
 			bri: 254,
 			hue: 61354,
 			sat: 195,
-			xy: [
-				0.4529,
-				0.1963
-			],
-			ct: 497
 		}
   },
   sass: {
@@ -279,11 +174,6 @@ export const defaultAmbientLightsRules: AmbientLightsRules = {
 			bri: 254,
 			hue: 61354,
 			sat: 195,
-			xy: [
-				0.4529,
-				0.1963
-			],
-			ct: 497
 		}
   },
   sql: {
@@ -292,11 +182,6 @@ export const defaultAmbientLightsRules: AmbientLightsRules = {
 			bri: 254,
 			hue: 41491,
 			sat: 78,
-			xy: [
-				0.312,
-				0.328
-			],
-			ct: 153
 		}
   },
   swift: {
@@ -305,11 +190,6 @@ export const defaultAmbientLightsRules: AmbientLightsRules = {
 			bri: 254,
 			hue: 7036,
 			sat: 209,
-			xy: [
-				0.5184,
-				0.409
-			],
-			ct: 480
 		}
   },
   typescript: {
@@ -318,11 +198,6 @@ export const defaultAmbientLightsRules: AmbientLightsRules = {
 			bri: 254,
 			hue: 44304,
 			sat: 254,
-			xy: [
-				0.1554,
-				0.1325
-			],
-			ct: 153
 		}
   },
   typescriptreact: {
@@ -331,11 +206,6 @@ export const defaultAmbientLightsRules: AmbientLightsRules = {
 			bri: 254,
 			hue: 44304,
 			sat: 254,
-			xy: [
-				0.1554,
-				0.1325
-			],
-			ct: 153
 		}
   }
 };

--- a/src/hue/group.ts
+++ b/src/hue/group.ts
@@ -52,5 +52,5 @@ export async function setDefaultGroupState(state: any) {
   const groupIDs = Object.keys(groups)
       .filter(groupID => groups[groupID].name === defaultGroup);
   const groupID = groupIDs[0] ? groupIDs[0] : 0;
-  turnGroupState(+groupID, state);
+  await turnGroupState(+groupID, state);
 }

--- a/src/hue/huetility.ts
+++ b/src/hue/huetility.ts
@@ -115,11 +115,11 @@ export class GroupsAPI extends RegisteredBridgeAPI {
     this.baseUrl = `${this.baseUrl}/groups`;
   }
 
-  setGroupState(groupID: number, state: any) {
+  async setGroupState(groupID: number, state: any) {
     return RP.put(`${this.baseUrl}/${groupID}/action`, {
       json: true,
       body: state
-    }).then(HandleSuccessResponse)
+    }).then(HandleSuccessResponse);
   }
 
   setGroupsState(groupIDs: number[], state: any) {


### PR DESCRIPTION
This PR is to remove `xy` and `ct` light settings from the default configuration to avoid flashing unrelated colors from `xy` color space during color transition.